### PR TITLE
4.3 HMI BETA fix Saving to EEPROM issue with Preinfusion (PI)

### DIFF
--- a/Beta/read.me
+++ b/Beta/read.me
@@ -1,2 +1,3 @@
 Holding bin for test files
 5.7.24 AJG - Updated PI tab to have Printh 23 02 50 01 so it properly saves upon "Save" and you can begin brewing without restarting the machine.
+5.7.24 AJG - Updated back button for Transition to go to Home and used explicit page # instead of bp (Current page) so the More tab went to previous tab properly instead of being stuck.

--- a/Beta/read.me
+++ b/Beta/read.me
@@ -1,1 +1,2 @@
 Holding bin for test files
+5.7.24 AJG - Updated PI tab to have Printh 23 02 50 01 so it properly saves upon "Save" and you can begin brewing without restarting the machine.


### PR DESCRIPTION
4.3 HMI BETA fix Saving to EEPROM issue with Preinfusion (PI)
Added missing Printh at top of the PI page.